### PR TITLE
Added javax.xml.bind to all target platforms to fix Java11 issues.

### DIFF
--- a/targetPlatforms/eclipse-modeling-oxygen-0.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-0.target
@@ -34,5 +34,9 @@
 <unit id="org.eclipse.xsd.sdk.feature.group" version="2.13.0.v20170609-0928"/>
 <repository location="http://download.eclipse.org/releases/oxygen/201706281000"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository"/>
+</location>
 </locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-oxygen-1.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-1.target
@@ -34,5 +34,9 @@
 <unit id="org.eclipse.xsd.sdk.feature.group" version="2.13.0.v20170609-0928"/>
 <repository location="http://download.eclipse.org/releases/oxygen/201710111001"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository"/>
+</location>
 </locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-oxygen-2.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-2.target
@@ -34,5 +34,9 @@
 <unit id="org.eclipse.xsd.sdk.feature.group" version="2.13.0.v20170609-0928"/>
 <repository location="http://download.eclipse.org/releases/oxygen/201712201001"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository"/>
+</location>
 </locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-oxygen-3.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-3.target
@@ -34,5 +34,9 @@
 <unit id="org.eclipse.xsd.sdk.feature.group" version="2.13.0.v20170609-0928"/>
 <repository location="http://download.eclipse.org/releases/oxygen/201804111000"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository"/>
+</location>
 </locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-photon-0.target
+++ b/targetPlatforms/eclipse-modeling-photon-0.target
@@ -34,5 +34,9 @@
 <unit id="org.eclipse.xsd.sdk.feature.group" version="2.14.0.v20180131-0817"/>
 <repository location="http://download.eclipse.org/releases/photon/201806271001"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
+</location>
 </locations>
 </target>


### PR DESCRIPTION
We experienced a problem in a Java 11 build that reported the missing javax.xml.bind package. These have been removed in Java 11, so we add it explicitly now.