### PR TITLE
Use separate deployment profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,8 @@
 
 		<!-- Build configuration of project itself -->
 		<profile>
-			<id>local-build</id>
-			<activation>
-				<file>
-					<exists>profileActivator_LocalBuild_3247</exists>
-				</file>
-			</activation>
-
+			<id>local-build-deployable</id>
+			<!-- activate this profile explicitly by adding -Plocal-build-deployable to the maven command -->
 			<distributionManagement>
 				<snapshotRepository>
 					<id>ossrh</id>
@@ -55,7 +50,33 @@
 					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 				</repository>
 			</distributionManagement>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
+		<profile>
+			<id>local-build</id>
+			<activation>
+				<file>
+					<exists>profileActivator_LocalBuild_3247</exists>
+				</file>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>
@@ -98,20 +119,6 @@
 										</artifact>
 									</artifacts>
 								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
Same change as done in MDSD-Tools/Maven-Build-Parents#3. Users have to activate the deployment profile manually now.