### PR TITLE
Update mwe2lib dependency to 0.2.0

### DIFF
--- a/targetPlatforms/eclipse-modeling-2020-06.target
+++ b/targetPlatforms/eclipse-modeling-2020-06.target
@@ -40,8 +40,8 @@
       <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/0.1.1/"/>
-      <unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.1.202006081152"/>
+      <repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/0.2.0/"/>
+      <unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.2.0.202010091524"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
Updated dependency to mwe2lib release 0.2.0. Since the mwe2lib itself was updated to 2020-06 target platform, the update only concerns the 2020-06 target platform.