### PR TITLE
Increment version to 0.2.1-SNAPSHOT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 MDSDToolsPipeline {
     skipArchive true
     skipQualityMetrics true
+    skipDeploy false
     deploySonatype {
         gpgId = '6819ab28-7bb8-4f24-b687-67f014150f9c'
         settingsId = 'fc491284-5a6e-46de-a386-0c3de60e715a'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 MDSDToolsPipeline {
     skipArchive true
     skipQualityMetrics true
-    skipDeploy false
     deploySonatype {
         gpgId = '6819ab28-7bb8-4f24-b687-67f014150f9c'
         settingsId = 'fc491284-5a6e-46de-a386-0c3de60e715a'

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-target-platforms</artifactId>
-	<version>0.1.10-SNAPSHOT</version>
+	<version>0.2.0</version>
 
 	<name>Eclipse Target Platforms</name>
 	<description>Shared target platforms for tycho-based builds.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-target-platforms</artifactId>
-	<version>0.2.0</version>
+	<version>0.2.1-SNAPSHOT</version>
 
 	<name>Eclipse Target Platforms</name>
 	<description>Shared target platforms for tycho-based builds.</description>


### PR DESCRIPTION
The version number was incremented due to a potentially incompatible change in the ecore workflow library. The release 0.2.0 has already been staged with sonatype. Incremented snapshot version to 0.2.1-SNAPSHOT.