### PR TITLE
Add validation of target platforms during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,18 +188,18 @@
 							<checkDependencies>true</checkDependencies>
 							<checkProvisioning>true</checkProvisioning>
 							<targetFiles>
-								<targetFile>targetPlatforms/eclipse-modeling-oxygen-0.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-oxygen-1.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-oxygen-2.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-oxygen-3.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-photon-0.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-2018-09.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-2019-03.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-2019-06.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-2020-03.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-2020-06.target</targetFile>
-								<targetFile>targetPlatforms/eclipse-modeling-2020-12.target</targetFile>
 								<targetFile>targetPlatforms/eclipse-modeling-2021-09.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2020-12.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2020-06.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2020-03.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2019-06.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2019-03.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2018-09.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-photon-0.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-3.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-2.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-1.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-0.target</targetFile>
 							</targetFiles>
 						</configuration>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
 					<exists>profileActivator_LocalBuild_3247</exists>
 				</file>
 			</activation>
+			<properties>
+				<tycho.version>2.5.0</tycho.version>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -167,6 +170,38 @@
 								</configuration>
 							</execution>
 						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>target-platform-validation-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<executions>
+							<execution>
+								<id>validate-targets</id>
+								<phase>validate</phase>
+								<goals>
+									<goal>validate-target-platform</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<checkDependencies>true</checkDependencies>
+							<checkProvisioning>true</checkProvisioning>
+							<targetFiles>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-0.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-1.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-2.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-oxygen-3.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-photon-0.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2018-09.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2019-03.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2019-06.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2020-03.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2020-06.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2020-12.target</targetFile>
+								<targetFile>targetPlatforms/eclipse-modeling-2021-09.target</targetFile>
+							</targetFiles>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/targetPlatforms/eclipse-modeling-2018-09.target
+++ b/targetPlatforms/eclipse-modeling-2018-09.target
@@ -41,8 +41,8 @@
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-			<repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
 		</location>
 	</locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-2019-03.target
+++ b/targetPlatforms/eclipse-modeling-2019-03.target
@@ -40,9 +40,9 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20190226160451/repository"/>
       <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
     </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
-      <unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-    </location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
+		</location>
   </locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-2021-09.target
+++ b/targetPlatforms/eclipse-modeling-2021-09.target
@@ -7,30 +7,30 @@
       <unit id="org.eclipse.epp.mpc.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.e4.core.tools.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.cdo.epp" version="0.0.0"/>
-      <unit id="org.eclipse.emf.compare.ide.ui.source" version="0.0.0"/>
-      <unit id="org.eclipse.emf.compare.source" version="0.0.0"/>
-      <unit id="org.eclipse.emf.compare.diagram.sirius.source" version="0.0.0"/>
-      <unit id="org.eclipse.emf.compare.egit" version="0.0.0"/>
-      <unit id="org.eclipse.emf.ecoretools.design" version="0.0.0"/>
-      <unit id="org.eclipse.emf.ecp.emfforms.sdk.feature" version="0.0.0"/>
-      <unit id="org.eclipse.emf.parsley.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.emf.parsley.sdk.source" version="0.0.0"/>
-      <unit id="org.eclipse.emf.query.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.emf.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.emf.transaction.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.emf.validation.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.gef.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.gmf.runtime.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.jdt" version="0.0.0"/>
-      <unit id="org.eclipse.mylyn.wikitext_feature" version="0.0.0"/>
-      <unit id="org.eclipse.oomph.setup" version="0.0.0"/>
-      <unit id="org.eclipse.ocl.all.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.pde" version="0.0.0"/>
-      <unit id="org.eclipse.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.uml2.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.xsd.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.tips.feature" version="0.0.0"/>
+      <unit id="org.eclipse.emf.cdo.epp.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.compare.ide.ui.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.compare.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.compare.diagram.sirius.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.compare.egit.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.ecoretools.design.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.parsley.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.parsley.sdk.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.query.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.validation.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.oomph.setup.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.ocl.all.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.xsd.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.tips.feature.feature.group" version="0.0.0"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <repository location="http://download.eclipse.org/releases/2021-09/202109151000"/>

--- a/targetPlatforms/eclipse-modeling-oxygen-0.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-0.target
@@ -41,8 +41,8 @@
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-			<repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
 		</location>
 	</locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-oxygen-1.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-1.target
@@ -41,8 +41,8 @@
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-			<repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
 		</location>
 	</locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-oxygen-2.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-2.target
@@ -41,8 +41,8 @@
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-			<repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
 		</location>
 	</locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-oxygen-3.target
+++ b/targetPlatforms/eclipse-modeling-oxygen-3.target
@@ -41,8 +41,8 @@
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-			<repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
 		</location>
 	</locations>
 </target>

--- a/targetPlatforms/eclipse-modeling-photon-0.target
+++ b/targetPlatforms/eclipse-modeling-photon-0.target
@@ -41,8 +41,8 @@
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201904021150"/>
-			<repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/releases/"/>
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.1.0.201907111715"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
This PR introduces an automated validation of the provided target platform files. In addition, the PR fixes broken target platform descriptions.

I stole the fix of the 2021-09 target platform from #34. I hope this is ok.